### PR TITLE
Buildifer 2 support byte string and load comments

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -33,8 +33,8 @@ gazelle_dependencies()
 go_repository(
     name = "skylark_syntax",
     importpath = "go.starlark.net",
-    sum = "h1:Qoe+9POtDT51UBQ8XEnS9QKeHDQzEl2QRh3eok9R4aw=",
-    version = "v0.0.0-20200203144150-6677ee5c7211",
+    sum = "",
+    version = "v0.0.0-20220213143740-c55a923347b1",
 )
 
 http_archive(

--- a/build/print.go
+++ b/build/print.go
@@ -446,19 +446,20 @@ func (p *printer) expr(v Expr, outerPrec int) {
 	case *StringExpr:
 		// If the Token is a correct quoting of Value and has double quotes, use it,
 		// also use it if it has single quotes and the value itself contains a double quote symbol
-		// or if it's a raw string literal (starts with "r").
+		// or if it's a raw string literal (starts with "r") or a byte
+		// literal (starts with "b").
 		// This preserves the specific escaping choices that BUILD authors have made.
 		s, triple, err := Unquote(v.Token)
 		if err == nil && s == v.Value && triple == v.TripleQuote {
-			if strings.HasPrefix(v.Token, `r`) {
+			if strings.HasPrefix(v.Token, "r") || strings.HasPrefix(v.Token, "b") {
 				// Raw string literal
 				token := v.Token
 				if strings.HasSuffix(v.Token, `'`) && !strings.ContainsRune(v.Value, '"') {
 					// Single quotes but no double quotes inside the string, replace with double quotes
 					if strings.HasSuffix(token, `'''`) {
-						token = `r"""` + token[4:len(token)-3] + `"""`
+						token = token[0:1] + `"""` + token[4:len(token)-3] + `"""`
 					} else if strings.HasSuffix(token, `'`) {
-						token = `r"` + token[2:len(token)-1] + `"`
+						token = token[0:1] + `"` + token[2:len(token)-1] + `"`
 					}
 				}
 				p.printf("%s", token)

--- a/build/quote.go
+++ b/build/quote.go
@@ -90,6 +90,10 @@ func Unquote(quoted string) (s string, triple bool, err error) {
 		raw = true
 		quoted = quoted[1:]
 	}
+	if strings.HasPrefix(quoted, "b") {
+		raw = true
+		quoted = quoted[1:]
+	}
 
 	if len(quoted) < 2 {
 		err = fmt.Errorf("string literal too short")

--- a/convertast/convert_ast.go
+++ b/convertast/convert_ast.go
@@ -188,7 +188,8 @@ func convExpr(e syntax.Expr) build.Expr {
 			return &build.StringExpr{
 				Value:       e.Value.(string),
 				TripleQuote: strings.HasPrefix(e.Raw, "b\"\"\""),
-				Comments:    convComments(e.Comments())}
+				Comments:    convComments(e.Comments()),
+				Token:       "b\"" + e.Value.(string) + "\""}
 		}
 	case *syntax.Ident:
 		return &build.Ident{Name: e.Name, Comments: convComments(e.Comments())}

--- a/convertast/convert_ast.go
+++ b/convertast/convert_ast.go
@@ -183,6 +183,11 @@ func convExpr(e syntax.Expr) build.Expr {
 				Value:       e.Value.(string),
 				TripleQuote: strings.HasPrefix(e.Raw, "\"\"\""),
 				Comments:    convComments(e.Comments())}
+		case syntax.BYTES:
+			return &build.StringExpr{
+				Value:       string(e.Value.([]byte)),
+				TripleQuote: strings.HasPrefix(e.Raw, "\"\"\""),
+				Comments:    convComments(e.Comments())}
 		}
 	case *syntax.Ident:
 		return &build.Ident{Name: e.Name, Comments: convComments(e.Comments())}

--- a/convertast/convert_ast.go
+++ b/convertast/convert_ast.go
@@ -57,6 +57,7 @@ func convStmt(stmt syntax.Stmt) build.Expr {
 		load := &build.LoadStmt{
 			Module:       convExpr(stmt.Module).(*build.StringExpr),
 			ForceCompact: singleLine(stmt),
+			Comments:     convComments(stmt.Comments()),
 		}
 		for _, ident := range stmt.From {
 			load.From = append(load.From, convExpr(ident).(*build.Ident))
@@ -185,8 +186,8 @@ func convExpr(e syntax.Expr) build.Expr {
 				Comments:    convComments(e.Comments())}
 		case syntax.BYTES:
 			return &build.StringExpr{
-				Value:       string(e.Value.([]byte)),
-				TripleQuote: strings.HasPrefix(e.Raw, "\"\"\""),
+				Value:       e.Value.(string),
+				TripleQuote: strings.HasPrefix(e.Raw, "b\"\"\""),
 				Comments:    convComments(e.Comments())}
 		}
 	case *syntax.Ident:

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.15
 
 require (
 	github.com/golang/protobuf v1.4.3
-	go.starlark.net v0.0.0-20210223155950-e043a3d3c984
+	go.starlark.net v0.0.0-20220213143740-c55a923347b1
 	google.golang.org/protobuf v1.25.0
 )

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,8 @@ github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 go.starlark.net v0.0.0-20210223155950-e043a3d3c984 h1:xwwDQW5We85NaTk2APgoN9202w/l0DVGp+GZMfsrh7s=
 go.starlark.net v0.0.0-20210223155950-e043a3d3c984/go.mod h1:t3mmBBPzAVvK0L0n1drDmrQsJ8FoIx4INCqVMTr/Zo0=
+go.starlark.net v0.0.0-20220213143740-c55a923347b1 h1:CIAbrK9/d5xfj5LlSS+yLtP6BSCNZD3uvKcpahLzkX0=
+go.starlark.net v0.0.0-20220213143740-c55a923347b1/go.mod h1:t3mmBBPzAVvK0L0n1drDmrQsJ8FoIx4INCqVMTr/Zo0=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=


### PR DESCRIPTION
Adds support in buildifer2 for comments on `load` statements and support for byte strings.

Bytes was added to starlark-go here: https://github.com/google/starlark-go/pull/330