### PR TITLE
Add a native.sh_binary wrapping around the buildifier rule

### DIFF
--- a/buildifier/buildifier.bzl
+++ b/buildifier/buildifier.bzl
@@ -19,9 +19,11 @@ _buildifier = rule(
 
 def buildifier(name = None, tags = [], **kwargs):
     """
-    Wrapper for the _buildifier rule. Adds 'manual' to the tags.
+    Wrapper for the _buildifier rule. Adds 'manual' to the tags and ensures windows compatibility.
 
     Args:
+      name: The name to be used for the rule
+      tags: The tags to be used for the rule
       **kwargs: all parameters for _buildifier
     """
 

--- a/buildifier/buildifier.bzl
+++ b/buildifier/buildifier.bzl
@@ -17,7 +17,7 @@ _buildifier = rule(
     executable = True,
 )
 
-def buildifier(**kwargs):
+def buildifier(name=None, tags=[], **kwargs):
     """
     Wrapper for the _buildifier rule. Adds 'manual' to the tags.
 
@@ -25,11 +25,17 @@ def buildifier(**kwargs):
       **kwargs: all parameters for _buildifier
     """
 
-    tags = kwargs.get("tags", [])
     if "manual" not in tags:
-        tags.append("manual")
-        kwargs["tags"] = tags
-    _buildifier(**kwargs)
+        tags = tags + ["manual"]
+
+    _buildifier(name="{}.sh".format(name), tags=tags, **kwargs)
+
+    native.sh_binary(
+        name = name,
+        srcs = ["{}.sh".format(name)],
+        data = [":{}.sh".format(name)],
+        tags=tags,
+    )
 
 def _buildifier_test_impl(ctx):
     return [buildifier_impl_factory(ctx, test_rule = True)]

--- a/buildifier/buildifier.bzl
+++ b/buildifier/buildifier.bzl
@@ -17,7 +17,7 @@ _buildifier = rule(
     executable = True,
 )
 
-def buildifier(name=None, tags=[], **kwargs):
+def buildifier(name = None, tags = [], **kwargs):
     """
     Wrapper for the _buildifier rule. Adds 'manual' to the tags.
 
@@ -28,13 +28,13 @@ def buildifier(name=None, tags=[], **kwargs):
     if "manual" not in tags:
         tags = tags + ["manual"]
 
-    _buildifier(name="{}.sh".format(name), tags=tags, **kwargs)
+    _buildifier(name = "{}.sh".format(name), tags = tags, **kwargs)
 
     native.sh_binary(
         name = name,
         srcs = ["{}.sh".format(name)],
         data = [":{}.sh".format(name)],
-        tags=tags,
+        tags = tags,
     )
 
 def _buildifier_test_impl(ctx):


### PR DESCRIPTION
This adds windows support in an incredibly minimal and non intrusive way with zero additional maintenance burden.