### PR TITLE
Add Rewriter rule to position Package() after loads in BUILD file (#1138)

### DIFF
--- a/build/BUILD.bazel
+++ b/build/BUILD.bazel
@@ -40,7 +40,10 @@ go_test(
         "rule_test.go",
         "walk_test.go",
     ],
-    data = glob(["testdata/*", "rewrite_test_files/*"]) + [
+    data = glob([
+        "testdata/*",
+        "rewrite_test_files/*",
+    ]) + [
         # parse.y.go is checked in to satisfy the Go community
         # https://github.com/bazelbuild/buildtools/issues/14
         # this test ensures it doesn't get stale.

--- a/build/BUILD.bazel
+++ b/build/BUILD.bazel
@@ -40,14 +40,12 @@ go_test(
         "rule_test.go",
         "walk_test.go",
     ],
-    data = glob(["testdata/*"]) + [
+    data = glob(["testdata/*", "rewrite_test_files/*"]) + [
         # parse.y.go is checked in to satisfy the Go community
         # https://github.com/bazelbuild/buildtools/issues/14
         # this test ensures it doesn't get stale.
         "parse.y.baz.go",
         "parse.y.go",
-        "rewrite_test_files/original_formatted.star",
-        "rewrite_test_files/original.star",
     ],
     embed = [":go_default_library"],
     deps = [

--- a/build/rewrite.go
+++ b/build/rewrite.go
@@ -1109,7 +1109,8 @@ func removeParens(f *File, _ *Rewriter) {
 // be fine for printing (the only current usecase within this package), but
 // may cause confusion for future alternative usages of this Rewrite logic.
 func reorderPackageAfterLoadBeforeRules(f *File, _ *Rewriter) {
-	var lastLoadIndex, packageFuncIndex int
+	lastLoadIndex := -1
+	packageFuncIndex := -1
 	var packageFunc *CallExpr
 	for idx, s := range f.Stmt {
 		switch s := s.(type) {
@@ -1123,7 +1124,7 @@ func reorderPackageAfterLoadBeforeRules(f *File, _ *Rewriter) {
 		}
 	}
 
-	if packageFunc == nil {
+	if lastLoadIndex == -1 || packageFuncIndex == -1 {
 		// no reordering necessary
 		return
 	}

--- a/build/rewrite_test.go
+++ b/build/rewrite_test.go
@@ -24,9 +24,9 @@ import (
 	"testing"
 )
 
-var workingDir string = path.Join(os.Getenv("TEST_SRCDIR"), os.Getenv("TEST_WORKSPACE"), "build")
-var originalFilePath = workingDir + "/rewrite_test_files/original.star"
-var formattedFilePath = workingDir + "/rewrite_test_files/original_formatted.star"
+var workingDir string = path.Join(os.Getenv("TEST_SRCDIR"), os.Getenv("TEST_WORKSPACE"), "build", "rewrite_test_files")
+var originalFilePath = path.Join(workingDir, "original.star")
+var formattedFilePath = path.Join(workingDir, "original_formatted.star")
 
 var originalBytes, _ = ioutil.ReadFile(originalFilePath)
 var originalFile, _ = ParseDefault(originalFilePath, originalBytes)
@@ -47,7 +47,8 @@ func TestRewriterRegular(t *testing.T) {
 	var modifyBytes, _ = ioutil.ReadFile(originalFilePath)
 	var modifiedFile, _ = ParseDefault(originalFilePath, modifyBytes)
 
-	// Perform rewrite on loaded file, rewrite should do nothing here
+	// Perform rewrite on loaded file, rewrite should do nothing here because the file
+	// has no needed modifations for the rewrites scoped to include scopeDefault.
 	Rewrite(modifiedFile)
 
 	// Initialize printers to obtain bytes later for different types of printers
@@ -60,7 +61,7 @@ func TestRewriterRegular(t *testing.T) {
 	originalPrinter.file(originalFile)
 	modifiedPrinter.file(modifiedFile)
 
-	// Assert that bytes to be writter are same as original bytes and different from formatted
+	// Assert that bytes to be written are same as original bytes and different from formatted
 	if !bytes.Equal(originalPrinter.Bytes(), modifiedPrinter.Bytes()) {
 		t.Error("Original Printer should equal Modified Printer")
 	}
@@ -74,7 +75,7 @@ func TestRewriterWithRewriter(t *testing.T) {
 	var modifyBytes, _ = ioutil.ReadFile(originalFilePath)
 	var modifiedFile, _ = ParseDefault(originalFilePath, modifyBytes)
 
-	// Perform rewrite with rewriter on loaded file, should proceed to reorder
+	// Perform rewrite with rewriter on loaded file, should proceed to reorder arguments
 	rewriter.Rewrite(modifiedFile)
 
 	// Initialize printers to obtain bytes later for different types of printers
@@ -93,5 +94,45 @@ func TestRewriterWithRewriter(t *testing.T) {
 	}
 	if bytes.Equal(originalPrinter.Bytes(), modifiedPrinter.Bytes()) {
 		t.Error("Original Printer should not equal Modified Printer")
+	}
+}
+
+func TestBUILDFileOrderingRewriter(t *testing.T) {
+	originalFilePath := path.Join(workingDir, "ordering_test.original.bazel")
+	formattedFilePath := path.Join(workingDir, "ordering_test.formatted.bazel")
+
+	// Load the files as a BUILD
+	modifyBytes, _ := ioutil.ReadFile(originalFilePath)
+	modifiedFile, _ := ParseBuild(originalFilePath, modifyBytes)
+	originalBytes, _ := ioutil.ReadFile(originalFilePath)
+	originalFile, _ := ParseBuild(originalFilePath, originalBytes)
+	formattedBytes, _ := ioutil.ReadFile(formattedFilePath)
+	formattedFile, _ := ParseBuild(formattedFilePath, formattedBytes)
+
+	// Perform rewrite on loaded file, should proceed to reorder calls
+	Rewrite(modifiedFile)
+
+	// Initialize printers to obtain bytes later for different types of printers
+	// We will check bytes from printers because that is our source of truth before writing to new file
+	formattedPrinter := &printer{fileType: formattedFile.Type}
+	originalPrinter := &printer{fileType: originalFile.Type}
+	modifiedPrinter := &printer{fileType: modifiedFile.Type}
+
+	formattedPrinter.file(formattedFile)
+	originalPrinter.file(originalFile)
+	modifiedPrinter.file(modifiedFile)
+
+	// Assert that bytes to be written is same as formmatted bytes and different from original
+	if bytes.Equal(formattedPrinter.Bytes(), modifiedPrinter.Bytes()) {
+		t.Errorf("Formatted Printer should equal Modified Printer\n\n\nmodified:\n%s\n\nformatted:\n%s\n\n",
+			modifiedPrinter.String(),
+			formattedPrinter.String(),
+		)
+	}
+	if bytes.Equal(originalPrinter.Bytes(), modifiedPrinter.Bytes()) {
+		t.Errorf("Original Printer should not equal Modified Printer\n\n\nmodified:\n%s\n\noriginal:\n%s\n\n",
+			modifiedPrinter.String(),
+			formattedPrinter.String(),
+		)
 	}
 }

--- a/build/rewrite_test.go
+++ b/build/rewrite_test.go
@@ -123,7 +123,7 @@ func TestBUILDFileOrderingRewriter(t *testing.T) {
 	modifiedPrinter.file(modifiedFile)
 
 	// Assert that bytes to be written is same as formmatted bytes and different from original
-	if bytes.Equal(formattedPrinter.Bytes(), modifiedPrinter.Bytes()) {
+	if !bytes.Equal(formattedPrinter.Bytes(), modifiedPrinter.Bytes()) {
 		t.Errorf("Formatted Printer should equal Modified Printer\n\n\nmodified:\n%s\n\nformatted:\n%s\n\n",
 			modifiedPrinter.String(),
 			formattedPrinter.String(),

--- a/build/rewrite_test_files/ordering_test.formatted.bazel
+++ b/build/rewrite_test_files/ordering_test.formatted.bazel
@@ -7,9 +7,9 @@ load("//keep.bzl", "library_keep") # keep
 
 load("//bar.bzl", "library_y")
 
-package(default_visibility="//:__subpackages__")
-
 # gazelle:directive
+
+package(default_visibility="//:__subpackages__")
 
 library_x(
 	name = "default_name"

--- a/build/rewrite_test_files/ordering_test.formatted.bazel
+++ b/build/rewrite_test_files/ordering_test.formatted.bazel
@@ -1,0 +1,20 @@
+"""
+Test file for rewrite.go
+"""
+# gazelle:load_directive
+load("//foo.bzl", "library_x")
+load("//keep.bzl", "library_keep") # keep
+
+load("//bar.bzl", "library_y")
+
+package(default_visibility="//:__subpackages__")
+
+# gazelle:directive
+
+library_x(
+	name = "default_name"
+)
+
+library_y(
+	name = "another_default_name"
+)

--- a/build/rewrite_test_files/ordering_test.original.bazel
+++ b/build/rewrite_test_files/ordering_test.original.bazel
@@ -1,0 +1,20 @@
+"""
+Test file for rewrite.go
+"""
+# gazelle:load_directive
+load("//foo.bzl", "library_x")
+load("//keep.bzl", "library_keep") # keep
+
+load("//bar.bzl", "library_y")
+
+# gazelle:directive
+
+library_x(
+	name = "default_name"
+)
+
+package(default_visibility="//:__subpackages__")
+
+library_y(
+	name = "another_default_name"
+)


### PR DESCRIPTION
This change adds a Rewrite rule to enforce the position of the `package()` function invocation within a BUILD file. This function must be called after all of the `load()`s, but before any rule, according to the [documentation](https://bazel.build/reference/be/functions#package).

Making this change here in the Rewriter also simplifies gazelle extensions manipulating this function in BUILD files as they no longer need to inspect the rest of the file for positional information.