### PR TITLE
Add Java options to api.proto

### DIFF
--- a/api_proto/api.proto
+++ b/api_proto/api.proto
@@ -16,6 +16,9 @@ package devtools.buildozer;
 
 option go_package = "api_proto";
 
+option java_package = "com.google.devtools.buildozer";
+option java_outer_classname = "BuildozerProtos";
+
 message Output {
   repeated Record records = 1;
   message Record {


### PR DESCRIPTION
Put into proper Java package `com.google.devtools.buildozer` and use `BuildozerProtos` as class name