### PR TITLE
buildozer: handle multiple glob tokens in set command

### DIFF
--- a/buildozer/buildozer_test.sh
+++ b/buildozer/buildozer_test.sh
@@ -1961,6 +1961,18 @@ function test_set_glob_srcs() {
 )'
 }
 
+function test_set_multiple_glob_srcs() {
+  # Note that the inner tokens are not sorted.
+  run "$no_deps" 'set srcs glob(["*.go", "*.cgo"])' '//pkg:edit'
+  assert_equals 'go_library(
+    name = "edit",
+    srcs = glob([
+        "*.go",
+        "*.cgo",
+    ]),
+)'
+}
+
 function test_fix_unused_load() {
   run 'load(":a.bzl", "a")
 # TODO: refactor

--- a/buildozer/buildozer_test.sh
+++ b/buildozer/buildozer_test.sh
@@ -1953,6 +1953,14 @@ function test_set_config_string() {
 )'
 }
 
+function test_set_glob_srcs() {
+  run "$no_deps" 'set srcs glob(["*.go"])' '//pkg:edit'
+  assert_equals 'go_library(
+    name = "edit",
+    srcs = glob(["*.go"]),
+)'
+}
+
 function test_fix_unused_load() {
   run 'load(":a.bzl", "a")
 # TODO: refactor

--- a/edit/buildozer.go
+++ b/edit/buildozer.go
@@ -575,6 +575,21 @@ func cmdSetIfAbsent(opts *Options, env CmdEnvironment) (*build.File, error) {
 	return env.File, nil
 }
 
+// isFunctionCall parses the args to see if they are arguments to a single
+// function call. This is naïve and does not attempt to parse the inner tokens.
+// example:
+//    the user input:  "glob(["*.c", "*.h"])"
+//    is tokenized to: "glob([\"*.c\",", "\"*.h\"])",
+func isFunctionCall(function string, args[] string) bool {
+	return strings.HasPrefix(args[0], function + "(") &&
+		strings.HasSuffix(args[len(args) -1], ")")
+}
+
+func functionCallExpr(args []string) build.Expr {
+	joined := strings.Join(args, "")
+	return &build.Ident{Name: joined}
+}
+
 func getAttrValueExpr(attr string, args []string, env CmdEnvironment) build.Expr {
 	switch {
 	case attr == "kind":
@@ -585,9 +600,8 @@ func getAttrValueExpr(attr string, args []string, env CmdEnvironment) build.Expr
 			list = append(list, &build.LiteralExpr{Token: i})
 		}
 		return &build.ListExpr{List: list}
-	case IsList(attr) && len(args) == 1 && strings.HasPrefix(args[0], "glob("):
-		// Single-value glob
-		return &build.Ident{Name: args[0]}
+	case IsList(attr) && isFunctionCall("glob", args):
+		return functionCallExpr(args)
 	case IsList(attr):
 		var list []build.Expr
 		for _, arg := range args {

--- a/edit/buildozer.go
+++ b/edit/buildozer.go
@@ -585,7 +585,10 @@ func getAttrValueExpr(attr string, args []string, env CmdEnvironment) build.Expr
 			list = append(list, &build.LiteralExpr{Token: i})
 		}
 		return &build.ListExpr{List: list}
-	case IsList(attr) && !(len(args) == 1 && strings.HasPrefix(args[0], "glob(")):
+	case IsList(attr) && len(args) == 1 && strings.HasPrefix(args[0], "glob("):
+		// Single-value glob
+		return &build.Ident{Name: args[0]}
+	case IsList(attr):
 		var list []build.Expr
 		for _, arg := range args {
 			list = append(list, getStringExpr(arg, env.Pkg))


### PR DESCRIPTION
To address #1249. This continues the special case handling for globs in `set X glob(...)` commands from #100. Ideally we should have a higher parsing level to extract the inner arguments from functions so they can be reorganized like regular files are. This does not work for `add X glob(...)` which follows the status quo. At the moment we only use `set` internally but can look at `add` too on the back burner. Thanks for this wonderful tool!