### PR TITLE
Restrict the kind query to start anchor

### DIFF
--- a/unused_deps/unused_deps.go
+++ b/unused_deps/unused_deps.go
@@ -354,7 +354,7 @@ func main() {
 	}
 	queryCmd = append(queryCmd, blazeFlags...)
 	queryCmd = append(
-		queryCmd, fmt.Sprintf("kind('(kt|java|android)_*', %s)", strings.Join(targetPatterns, " + ")))
+		queryCmd, fmt.Sprintf("kind('^(kt|java|android)_*', %s)", strings.Join(targetPatterns, " + ")))
 
 	log.Printf("running: %s %s", *buildTool, strings.Join(queryCmd, " "))
 	queryOut, err := cmdWithStderr(*buildTool, queryCmd...).Output()


### PR DESCRIPTION
We had rules such as `pkg_java_library` that were being caught by the kind pattern.

Force the prefix kind (i.e. java_) to anchor to the start of the label.