### PR TITLE
Only emit buildozer add deps if export exists

### DIFF
--- a/unused_deps/unused_deps.go
+++ b/unused_deps/unused_deps.go
@@ -288,7 +288,10 @@ func printCommands(label string, deps map[string]bool) (anyCommandPrinted bool) 
 					fmt.Printf("buildozer 'move deps runtime_deps %s' %s\n", str.Value, label)
 				} else {
 					// add dep's exported dependencies to label before removing dep
-					fmt.Printf("buildozer \"add deps $(%s query 'labels(exports, %s)' | tr '\\n' ' ')\" %s\n", *buildTool, str.Value, label)
+					fmt.Printf(
+						"deps=$(%s query 'labels(exports, %s)' | tr '\\n' ' '); [ -n \"$deps\" ] && buildozer \"add deps $deps\" %s\n",
+						*buildTool, str.Value, label,
+					)
 					fmt.Printf("buildozer 'remove deps %s' %s\n", str.Value, label)
 				}
 				anyCommandPrinted = true


### PR DESCRIPTION
Previously, unused_deps would emit `add deps` for all the exports of a particular label that it was removing. If there were no exports, the buildozer commands would fail complaining about having 0 arguments.

```
> buildozer "add deps $(bazel query 'labels(exports, @maven//:com_google_guava_guava)' | tr '\n' ' ')" //http-server/ce-kafka-http-server:http-server-test-jar
INFO: Invocation ID: cd696714-cd65-497d-b2cd-206dc679a610
Loading: 0 packages loaded
INFO: Empty results
Too few arguments for command 'add', expected at least 2.
```

We now guard against running the buildozer command only if the query returns values.

```
> deps=$(bazel query 'labels(exports, @maven//:com_google_guava_guava)' | tr '\n' ' '); [ -n "$deps" ] && buildozer "add deps $deps" //http-server/ce-kafka-http-server:http-server-test-jar
INFO: Invocation ID: f7d9a5fe-ef85-4ea8-8ac7-8eed6ae1a158
Loading: 0 packages loaded
INFO: Empty results
```