### PR TITLE
buildifier: honor `exclude_patterns` on Windows too

### DIFF
--- a/buildifier/internal/factory.bzl
+++ b/buildifier/internal/factory.bzl
@@ -159,8 +159,12 @@ def buildifier_impl_factory(ctx, test_rule = False):
     if ctx.attr.exclude_patterns:
         if test_rule and not ctx.attr.no_sandbox:
             fail("Cannot use 'exclude_patterns' in a test rule without 'no_sandbox'")
-        exclude_patterns = ["\\! -path %s" % shell.quote(pattern) for pattern in ctx.attr.exclude_patterns]
-        exclude_patterns_str = " ".join(exclude_patterns)
+        if ctx.executable.buildifier.extension.lower() == "exe":
+            exclude_patterns = [shell.quote(pattern.replace("/", "\\")) for pattern in ctx.attr.exclude_patterns]
+            exclude_patterns_str = ", ".join(exclude_patterns)
+        else:
+            exclude_patterns = ["\\! -path %s" % shell.quote(pattern) for pattern in ctx.attr.exclude_patterns]
+            exclude_patterns_str = " ".join(exclude_patterns)
 
     workspace = ""
     if test_rule and ctx.attr.no_sandbox:

--- a/buildifier/runner.bat.template
+++ b/buildifier/runner.bat.template
@@ -12,8 +12,21 @@ rem Get the absolute path to the buildifier executable
 for /f "tokens=2" %%i in ('findstr /r "\<buildifier\.exe\>" MANIFEST') do (set buildifier_abs_path=%%i)
 
 powershell ^
+function Should-Exclude($Path)^
+{^
+    $relPath = '.' + $Path.Substring('%BUILD_WORKSPACE_DIRECTORY%'.Length);^
+    foreach ($pattern in @(@@EXCLUDE_PATTERNS@@))^
+    {^
+        if ($relPath -clike $pattern)^
+        {^
+            return $true;^
+        };^
+    };^
+    return $false;^
+};^
 $Files = Get-ChildItem -LiteralPath '%BUILD_WORKSPACE_DIRECTORY:/=\%' -Recurse -File -ErrorAction SilentlyContinue ^|^
     Where-Object {^
+        (^
         $_.Name -eq 'BUILD.bazel' `^
         -or $_.Name -eq 'BUILD' `^
         -or $_.Name -eq 'WORKSPACE' `^
@@ -26,6 +39,7 @@ $Files = Get-ChildItem -LiteralPath '%BUILD_WORKSPACE_DIRECTORY:/=\%' -Recurse -
         -or $_.Name -clike 'BUILD.*.oss' `^
         -or $_.Name -clike 'WORKSPACE.*.bazel' `^
         -or $_.Name -clike 'WORKSPACE.*.oss'^
+        ) -and -not (Should-Exclude $_.Path)^
     };^
  ^<# Process files in batches of 100- to avoid exceeding CreateProcess' maximum length of 32,767 characters #^> ^
 $i = 0;^


### PR DESCRIPTION
The `exclude_patterns` parameter passed to `buildifier` macros happens to be ignored by the Windows runner script template, which the present change proposes to address.

The change tries to adhere to existing choices, by limiting the impact on `factory.bzl` where the `find`-suitable pattern can't be used by the embedded powershell script, and also by respecting the script's coding style.