### PR TITLE
buildifier_test: fix `FINDSTR: Cannot open MANIFEST`

### DIFF
--- a/buildifier/runner.bat.template
+++ b/buildifier/runner.bat.template
@@ -9,7 +9,15 @@ rem Unquote the arguments
 set stripped_args=%stripped_args:'=%
 
 rem Get the absolute path to the buildifier executable
-for /f "tokens=2" %%i in ('findstr /r "\<buildifier\.exe\>" MANIFEST') do (set buildifier_abs_path=%%i)
+if exist MANIFEST (
+    set manifest_file=MANIFEST
+) else if exist "%RUNFILES_MANIFEST_FILE%" (
+    set "manifest_file=%RUNFILES_MANIFEST_FILE:/=\%"
+) else (
+    >&2 echo Error: manifest file not found
+    exit /b 1
+)
+for /f "tokens=2" %%i in ('findstr /r "\<buildifier\.exe\>" "%manifest_file%"') do (set buildifier_abs_path=%%i)
 
 powershell ^
 $Files = Get-ChildItem -LiteralPath '%BUILD_WORKSPACE_DIRECTORY:/=\%' -Recurse -File -ErrorAction SilentlyContinue ^|^


### PR DESCRIPTION
This happens on Windows when using the `buildifier_test` macro:
```
INFO: Running command line: 'external\bazel_tools\tools\test\tw.exe' buildifier/test.bat
Executing tests from //buildifier:test
-----------------------------------------------------------------------------
FINDSTR: Cannot open MANIFEST
The expression after '&' in a pipeline element produced an object that was not valid. It must result in a command 
name, a script block, or a CommandInfo object.
At line:1 char:566
+ ...  -clike 'WORKSPACE.*.oss' }; foreach ($File in $Files) { & '' -mode=d ...
+                                                                ~~
    + CategoryInfo          : InvalidOperation: (:String) [], RuntimeException
    + FullyQualifiedErrorId : BadExpression

The expression after '&' in a pipeline element produced an object that was not valid. It must result in a command 
[...]
```

The present change simply consists in giving a second try with `$RUNFILES_MANIFEST_FILE` and failing fast should both be absent.