### PR TITLE
Add `-lint=suggest` to include replacement in `--format=json` output

### DIFF
--- a/buildifier/config/config.go
+++ b/buildifier/config/config.go
@@ -102,7 +102,7 @@ type Config struct {
 	Mode string `json:"mode,omitempty"`
 	// DiffMode is an alias for
 	DiffMode bool `json:"diffMode,omitempty"`
-	// Lint determines the lint mode: off, warn, or fix (default off)
+	// Lint determines the lint mode: off, warn, suggest, or fix (default off)
 	Lint string `json:"lint,omitempty"`
 	// Warnings is a comma-separated list of warning identifiers used in the lint mode or "all"
 	Warnings string `json:"warnings,omitempty"`
@@ -201,7 +201,7 @@ func (c *Config) Validate(args []string) error {
 		return err
 	}
 
-	if err := ValidateModes(&c.Mode, &c.Lint, &c.DiffMode); err != nil {
+	if err := ValidateModes(&c.Mode, &c.Lint, &c.DiffMode, &c.Format); err != nil {
 		return err
 	}
 

--- a/buildifier/config/config.go
+++ b/buildifier/config/config.go
@@ -103,7 +103,7 @@ type Config struct {
 	Mode string `json:"mode,omitempty"`
 	// DiffMode is an alias for
 	DiffMode bool `json:"diffMode,omitempty"`
-	// Lint determines the lint mode: off, warn, or fix (default off)
+	// Lint determines the lint mode: off, warn, suggest, or fix (default off)
 	Lint string `json:"lint,omitempty"`
 	// Warnings is a comma-separated list of warning identifiers used in the lint mode or "all"
 	Warnings string `json:"warnings,omitempty"`
@@ -207,7 +207,7 @@ func (c *Config) Validate(args []string) error {
 		return err
 	}
 
-	if err := ValidateModes(&c.Mode, &c.Lint, &c.DiffMode); err != nil {
+	if err := ValidateModes(&c.Mode, &c.Lint, &c.DiffMode, &c.Format); err != nil {
 		return err
 	}
 

--- a/buildifier/config/validation.go
+++ b/buildifier/config/validation.go
@@ -60,7 +60,7 @@ func isRecognizedMode(validModes []string, mode string) bool {
 }
 
 // ValidateModes validates flags --mode, --lint, and -d
-func ValidateModes(mode, lint *string, dflag *bool, additionalModes ...string) error {
+func ValidateModes(mode, lint *string, dflag *bool, format *string) error {
 	if *dflag {
 		if *mode != "" {
 			return fmt.Errorf("cannot specify both -d and -mode flags")
@@ -70,7 +70,6 @@ func ValidateModes(mode, lint *string, dflag *bool, additionalModes ...string) e
 
 	// Check mode.
 	validModes := []string{"check", "diff", "fix", "print_if_changed"}
-	validModes = append(validModes, additionalModes...)
 
 	if *mode == "" {
 		*mode = "fix"
@@ -89,6 +88,11 @@ func ValidateModes(mode, lint *string, dflag *bool, additionalModes ...string) e
 	case "fix":
 		if *mode != "fix" {
 			return fmt.Errorf("--lint=fix is only compatible with --mode=fix")
+		}
+
+	case "suggest":
+		if *format != "json" {
+			return fmt.Errorf("--lint=suggest is only compatible with --format=json")
 		}
 
 	default:

--- a/buildifier/config/validation.go
+++ b/buildifier/config/validation.go
@@ -96,7 +96,7 @@ func ValidateModes(mode, lint *string, dflag *bool, format *string) error {
 		}
 
 	default:
-		return fmt.Errorf("unrecognized lint mode %s; valid modes are warn and fix", *lint)
+return fmt.Errorf("unrecognized lint mode %s; valid modes are warn, suggest, and fix", *lint)
 	}
 
 	return nil

--- a/buildifier/config/validation.go
+++ b/buildifier/config/validation.go
@@ -98,7 +98,7 @@ func ValidateModes(mode, lint *string, dflag *bool, format *string) error {
 		}
 
 	default:
-		return fmt.Errorf("unrecognized lint mode %s; valid modes are warn and fix", *lint)
+return fmt.Errorf("unrecognized lint mode %s; valid modes are warn, suggest, and fix", *lint)
 	}
 
 	return nil

--- a/buildifier/config/validation.go
+++ b/buildifier/config/validation.go
@@ -62,7 +62,7 @@ func isRecognizedMode(validModes []string, mode string) bool {
 }
 
 // ValidateModes validates flags --mode, --lint, and -d
-func ValidateModes(mode, lint *string, dflag *bool, additionalModes ...string) error {
+func ValidateModes(mode, lint *string, dflag *bool, format *string) error {
 	if *dflag {
 		if *mode != "" {
 			return fmt.Errorf("cannot specify both -d and -mode flags")
@@ -72,7 +72,6 @@ func ValidateModes(mode, lint *string, dflag *bool, additionalModes ...string) e
 
 	// Check mode.
 	validModes := []string{"check", "diff", "fix", "print_if_changed"}
-	validModes = append(validModes, additionalModes...)
 
 	if *mode == "" {
 		*mode = "fix"
@@ -91,6 +90,11 @@ func ValidateModes(mode, lint *string, dflag *bool, additionalModes ...string) e
 	case "fix":
 		if *mode != "fix" {
 			return fmt.Errorf("--lint=fix is only compatible with --mode=fix")
+		}
+
+	case "suggest":
+		if *format != "json" {
+			return fmt.Errorf("--lint=suggest is only compatible with --format=json")
 		}
 
 	default:

--- a/buildifier/utils/diagnostics.go
+++ b/buildifier/utils/diagnostics.go
@@ -82,7 +82,7 @@ type warning struct {
 	AutoFixable bool         `json:"autoFixable"`
 	Message     string       `json:"message"`
 	URL         string       `json:"url"`
-Replacement *replacement `json:"replacement,omitempty"` // Optional replacement
+    Replacement *replacement `json:"replacement,omitempty"` // Optional replacement
 }
 
 type position struct {

--- a/buildifier/utils/diagnostics.go
+++ b/buildifier/utils/diagnostics.go
@@ -82,7 +82,7 @@ type warning struct {
 	AutoFixable bool         `json:"autoFixable"`
 	Message     string       `json:"message"`
 	URL         string       `json:"url"`
-	Replacement *replacement `json:"replacement"` // Optional replacement
+Replacement *replacement `json:"replacement,omitempty"` // Optional replacement
 }
 
 type position struct {

--- a/buildifier/utils/utils.go
+++ b/buildifier/utils/utils.go
@@ -131,6 +131,8 @@ func Lint(f *build.File, lint string, warningsList *[]string, verbose bool) []*w
 	switch lint {
 	case "warn":
 		return warn.FileWarnings(f, *warningsList, nil, warn.ModeWarn, fileReader)
+	case "suggest":
+		return warn.FileWarnings(f, *warningsList, nil, warn.ModeSuggest, fileReader)
 	case "fix":
 		warn.FixWarnings(f, *warningsList, verbose, fileReader)
 	}

--- a/buildifier/utils/utils.go
+++ b/buildifier/utils/utils.go
@@ -133,6 +133,8 @@ func Lint(f *build.File, lint string, warningsList *[]string, verbose bool) []*w
 	switch lint {
 	case "warn":
 		return warn.FileWarnings(f, *warningsList, nil, warn.ModeWarn, fileReader)
+	case "suggest":
+		return warn.FileWarnings(f, *warningsList, nil, warn.ModeSuggest, fileReader)
 	case "fix":
 		warn.FixWarnings(f, *warningsList, verbose, fileReader)
 	}


### PR DESCRIPTION
This PR adds a new CLI flag value for `-lint`, `suggest`. When used in conjunction with `--format=json` the output populates the new field `.files[].warnings[].replacement`.

Note that `start` and `end` are inconsistent with the existing fields.
- `.files[].warnings[].start` and `.files[].warnings[].end`
  - `.line` is a 1-indexed line number.
  - `.column` is a 1-indexed UTF-16 code unit.
- `.files[].warnings[].replacement.start` and `.files[].warnings[].replacement.end`
  - `.` is a 0-indexed byte positions.

Replacement positions are derived from `[]byte` arrays, so conversion (to the correct encoding) would be necessary. But also;
- Correctly detecting line endings in a manner consistent with the parser.
- Correctly handling multi-byte sequences (and potentially Unicode grapheme clusters) in a manner consistent with the parser.

As a result normalisation is difficult, bug prone, and unless `[]byte` usage is eliminated close to it's source, liable to carry a (minor) performance and memory penalty.

Output sample;

```
❯ buildifier -lint=suggest -mode=check -format json -v ___/BUILD.bazel
{
    "success": false,
    "files": [
        {
            "filename": "___/BUILD.bazel",
            "formatted": false,
            "valid": true,
            "warnings": [
                {
                    "start": {
                        "line": 259,
                        "column": 1
                    },
                    "end": {
                        "line": 259,
                        "column": 10
                    },
                    "category": "native-java-test",
                    "actionable": true,
                    "autoFixable": true,
                    "message": "Function \"java_test\" is not global anymore and needs to be loaded from \"@rules_java//java:java_test.bzl\".",
                    "url": "https://github.com/bazelbuild/buildtools/blob/main/WARNINGS.md#native-java-test",
                    "replacement": {
                        "start": 57,
                        "end": 57,
                        "content": "@rules_java//java:java_test.bzl\", \"java_test\")\nload(\""
                    }
                }
            ]
        }
    ]
}
```

The use case for this change is integrating suggested fixes with an internal tool.