### PR TITLE
buildifier: add *.BUILD.bazel to the list of analyzed patterns

### DIFF
--- a/buildifier/runner.bash.template
+++ b/buildifier/runner.bash.template
@@ -50,9 +50,9 @@ find . \
     -o -name BUILD.bazel \
     -o -name BUILD \
     -o -name '*.BUILD' \
+    -o -name '*.BUILD.bazel' \
     -o -name 'BUILD.*.bazel' \
     -o -name 'BUILD.*.oss' \
-    -o -name '*.BUILD.bazel' \
     -o -name MODULE.bazel \
     -o -name '*.MODULE.bazel' \
     -o -name WORKSPACE \

--- a/buildifier/runner.bash.template
+++ b/buildifier/runner.bash.template
@@ -52,6 +52,7 @@ find . \
     -o -name '*.BUILD' \
     -o -name 'BUILD.*.bazel' \
     -o -name 'BUILD.*.oss' \
+    -o -name '*.BUILD.bazel' \
     -o -name MODULE.bazel \
     -o -name '*.MODULE.bazel' \
     -o -name WORKSPACE \


### PR DESCRIPTION
Add another pattern to the buildifier template script, in order to handle `*.BUILD.bazel` files.
