### PR TITLE
Remove deprecated reading of env vars for determining diff program

### DIFF
--- a/buildifier/buildifier.go
+++ b/buildifier/buildifier.go
@@ -146,14 +146,10 @@ func main() {
 	build.DisableRewrites = c.DisableRewrites
 	build.AllowSort = c.AllowSort
 
-	differ, deprecationWarning := differ.Find()
+	differ := differ.Find()
 	if c.DiffCommand != "" {
 		differ.Cmd = c.DiffCommand
 		differ.MultiDiff = c.MultiDiff
-	} else {
-		if deprecationWarning && c.Mode == "diff" {
-			fmt.Fprintf(os.Stderr, "buildifier: selecting diff program with the BUILDIFIER_DIFF, BUILDIFIER_MULTIDIFF, and DISPLAY environment variables is deprecated, use flags -diff_command and -multi_diff instead\n")
-		}
 	}
 
 	b := buildifier{c, differ}

--- a/differ/diff.go
+++ b/differ/diff.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"runtime"
-	"strings"
 )
 
 // Invocation of different diff commands, according to environment variables.
@@ -90,45 +88,10 @@ func (d *Differ) Run() error {
 }
 
 // Find returns the differ to use, using various environment variables.
-func Find() (*Differ, bool) {
+func Find() (*Differ) {
 	d := &Differ{}
-	deprecationWarning := false
-	if cmd := os.Getenv("BUILDIFIER_DIFF"); cmd != "" {
-		deprecationWarning = true
-		d.Cmd = cmd
-	}
 
-	// Load MultiDiff setting from environment.
-	knowMultiDiff := false
-	if md := os.Getenv("BUILDIFIER_MULTIDIFF"); md == "0" || md == "1" {
-		deprecationWarning = true
-		d.MultiDiff = md == "1"
-		knowMultiDiff = true
-	}
+	d.Cmd = "diff --unified"
 
-	if d.Cmd != "" {
-		if !knowMultiDiff {
-			lower := strings.ToLower(d.Cmd)
-			d.MultiDiff = strings.Contains(lower, "tkdiff") &&
-				isatty(1) && os.Getenv("DISPLAY") != ""
-		}
-	} else {
-		if !knowMultiDiff {
-			d.MultiDiff = isatty(1) && os.Getenv("DISPLAY") != ""
-			if d.MultiDiff {
-				deprecationWarning = true
-			}
-		}
-		if d.MultiDiff {
-			d.Cmd = "tkdiff"
-		} else {
-			if runtime.GOOS == "windows" {
-				deprecationWarning = true
-				d.Cmd = "FC"
-			} else {
-				d.Cmd = "diff --unified"
-			}
-		}
-	}
-	return d, deprecationWarning
+	return d
 }

--- a/differ/diff.go
+++ b/differ/diff.go
@@ -87,8 +87,8 @@ func (d *Differ) Run() error {
 	return d.run(d.Cmd, d.Args...)
 }
 
-// Find returns the differ to use, using various environment variables.
-func Find() (*Differ) {
+// Find returns the default differ to use.
+func Find() *Differ {
 	d := &Differ{}
 
 	d.Cmd = "diff --unified"


### PR DESCRIPTION
My environment for whatever reason has `DISPLAY=1`, and so in diff mode I always get this warning. A whole bunch of this has been deprecated since 2019, just delete it so I can silence it.