### PR TITLE
perf: preallocate sortStringExprs chunk slice size

### DIFF
--- a/build/rewrite.go
+++ b/build/rewrite.go
@@ -672,7 +672,7 @@ func sortStringExprs(list []Expr) []Expr {
 			}
 		}
 
-		var chunk []stringSortKey
+		chunk := make([]stringSortKey, 0, j-i)
 		for index, x := range list[i:j] {
 			chunk = append(chunk, makeSortKey(index, x.(*StringExpr)))
 		}


### PR DESCRIPTION
## Buildtools PR checklist

- [x] The code in this PR is covered by unit/integration tests.
- [x] I have tested these changes and provide testing instructions below.
- [x] I have either responded to, or resolved all Gemini comments on the PR.
- [x] I have read Google Eng Practices on [Small Changes](https://google.github.io/eng-practices/review/developer/small-cls.html), this PR either follows these guidelines or the description provides reasoning for why they can not be followed.

## Description

The list size is guaranteed and can be pre-\allocatted.
