### PR TITLE
perf: reduce allocations in the printer and string-list sorting

### DIFF
--- a/build/print.go
+++ b/build/print.go
@@ -1032,12 +1032,19 @@ func (p *printer) useCompactMode(start *Position, list *[]Expr, end *End, mode s
 // If multiLine is true, seq avoids the compact form even
 // for 0- and 1-element sequences.
 func (p *printer) seq(brack string, start *Position, list *[]Expr, end *End, mode seqMode, forceCompact, forceMultiLine bool) {
-	args := &[]Expr{}
-	for _, x := range *list {
-		// nil arguments may be added by some linter checks, filter them out because
-		// they may cause NPE.
-		if x != nil {
-			*args = append(*args, x)
+	// Filter out nil arguments (rare; added by some linter checks) that may cause a NPE, copying only if needed.
+	args := list
+	for i, x := range *list {
+		if x == nil {
+			filtered := make([]Expr, i, len(*list))
+			copy(filtered, (*list)[:i])
+			for _, y := range (*list)[i+1:] {
+				if y != nil {
+					filtered = append(filtered, y)
+				}
+			}
+			args = &filtered
+			break
 		}
 	}
 


### PR DESCRIPTION
## Buildtools PR checklist

- [x] The code in this PR is covered by unit/integration tests.
- [x] I have tested these changes and provide testing instructions below.
- [x] I have either responded to, or resolved all Gemini comments on the PR.
- [x] I have read Google Eng Practices on [Small Changes](https://google.github.io/eng-practices/review/developer/small-cls.html), this PR either follows these guidelines or the description provides reasoning for why they can not be followed.

## Description

Reduce array copying to only when necessary, which seems like the exception and not the norm.