### PR TITLE
Null-out Android env for non-Android macos builds

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -10,6 +10,9 @@ platforms:
     test_targets:
     - "//..."
   macos:
+    environment:
+      ANDROID_HOME: ""
+      ANDROID_NDK_HOME: ""
     test_targets:
     - "//..."
   macos_arm64:


### PR DESCRIPTION
The Intel `macos` deployment in BazelCI does not have the latest Android build tools installed. By default, BazelCI adds `ANDROID*` environment variables to builds, which registers an Android toolchain for any transitively-loaded Android deps, which causes a repo rule-level error.

To prevent this, this PR nulls out the `ANDROID*` environment variables.
