### PR TITLE
Allow JSONC in .buildifier.json config parsing

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -30,6 +30,7 @@ use_repo(
     go_deps,
     "com_github_golang_protobuf",
     "com_github_google_go_cmp",
+    "com_github_tailscale_hujson",
     "net_starlark_go",
     "org_golang_google_protobuf",
     "org_golang_x_tools",

--- a/buildifier/config/BUILD.bazel
+++ b/buildifier/config/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "config",
     srcs = [
         "config.go",
+        "jsonc.go",
         "validation.go",
     ],
     importpath = "github.com/bazelbuild/buildtools/buildifier/config",
@@ -12,12 +13,16 @@ go_library(
         "//tables",
         "//warn",
         "//wspace",
+        "@com_github_tailscale_hujson//:hujson",
     ],
 )
 
 go_test(
     name = "config_test",
-    srcs = ["config_test.go"],
+    srcs = [
+        "config_test.go",
+        "jsonc_test.go",
+    ],
     embed = [":config"],
 )
 

--- a/buildifier/config/config.go
+++ b/buildifier/config/config.go
@@ -151,11 +151,16 @@ func (c *Config) LoadFile() error {
 	return c.LoadReader(file)
 }
 
-// LoadReader unmarshals JSON data from the given reader.
+// LoadReader unmarshals JSON data from the given reader. JSON with comments
+// (JSONC) is supported.
 func (c *Config) LoadReader(in io.Reader) error {
 	data, err := io.ReadAll(in)
 	if err != nil {
 		return fmt.Errorf("reading config: %w", err)
+	}
+	data, err = parseJSONC(data)
+	if err != nil {
+		return fmt.Errorf("parsing config: %w", err)
 	}
 	if err := json.Unmarshal(data, c); err != nil {
 		return err

--- a/buildifier/config/config.go
+++ b/buildifier/config/config.go
@@ -163,7 +163,7 @@ func (c *Config) LoadReader(in io.Reader) error {
 		return fmt.Errorf("parsing config: %w", err)
 	}
 	if err := json.Unmarshal(data, c); err != nil {
-		return err
+		return fmt.Errorf("unmarshaling config: %w", err)
 	}
 	return nil
 }

--- a/buildifier/config/jsonc.go
+++ b/buildifier/config/jsonc.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2022 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import "github.com/tailscale/hujson"
+
+// parseJSONC converts JWCC/JSONC input (JSON with comments and trailing
+// commas) into standard JSON.
+func parseJSONC(src []byte) ([]byte, error) {
+	return hujson.Standardize(src)
+}

--- a/buildifier/config/jsonc_test.go
+++ b/buildifier/config/jsonc_test.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2022 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestParseJSONC(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want map[string]any
+	}{
+		{
+			name: "line comment",
+			in:   "{\"mode\": \"fix\"} // trailing comment\n",
+			want: map[string]any{"mode": "fix"},
+		},
+		{
+			name: "block comment",
+			in:   `{"mode": /* inline */ "fix"}`,
+			want: map[string]any{"mode": "fix"},
+		},
+		{
+			name: "comment-like sequences in strings",
+			in:   `{"url": "http://example.com", "note": "use // sparingly /* ok */"}`,
+			want: map[string]any{
+				"url":  "http://example.com",
+				"note": "use // sparingly /* ok */",
+			},
+		},
+		{
+			name: "trailing comma",
+			in:   `{"mode": "fix",}`,
+			want: map[string]any{"mode": "fix"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			data, err := parseJSONC([]byte(tc.in))
+			if err != nil {
+				t.Fatalf("parseJSONC() error = %v", err)
+			}
+			if !json.Valid(data) {
+				t.Fatalf("parseJSONC() = invalid JSON %q", data)
+			}
+
+			var got map[string]any
+			if err := json.Unmarshal(data, &got); err != nil {
+				t.Fatalf("json.Unmarshal() error = %v", err)
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+			for key, want := range tc.want {
+				if got[key] != want {
+					t.Fatalf("got[%q] = %v, want %v", key, got[key], want)
+				}
+			}
+		})
+	}
+}
+
+func TestLoadReaderJSONC(t *testing.T) {
+	input := `{
+  // Lint settings for the workspace.
+  "mode": "check",
+  /* Keep lint off until warnings are triaged. */
+  "lint": "off",
+  "warnings": "native-cc-binary", // single warning for now
+}`
+
+	c := New()
+	if err := c.LoadReader(strings.NewReader(input)); err != nil {
+		t.Fatalf("LoadReader() error = %v", err)
+	}
+
+	if c.Mode != "check" {
+		t.Errorf("Mode = %q, want %q", c.Mode, "check")
+	}
+	if c.Lint != "off" {
+		t.Errorf("Lint = %q, want %q", c.Lint, "off")
+	}
+	if c.Warnings != "native-cc-binary" {
+		t.Errorf("Warnings = %q, want %q", c.Warnings, "native-cc-binary")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,11 @@
 module github.com/bazelbuild/buildtools
 
-go 1.20
+go 1.23
 
 require (
 	github.com/golang/protobuf v1.5.0
 	github.com/google/go-cmp v0.5.9
+	github.com/tailscale/hujson v0.0.0-20260302212456-ecc657c15afd
 	go.starlark.net v0.0.0-20210223155950-e043a3d3c984
 	google.golang.org/protobuf v1.33.0
 )

--- a/go.sum
+++ b/go.sum
@@ -25,9 +25,12 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/tailscale/hujson v0.0.0-20260302212456-ecc657c15afd h1:Rf9uhF1+VJ7ZHqxrG8pJ6YacmHvVCmByDmGbAWCc/gA=
+github.com/tailscale/hujson v0.0.0-20260302212456-ecc657c15afd/go.mod h1:EbW0wDK/qEUYI0A5bqq0C2kF8JTQwWONmGDBbzsxxHo=
 go.starlark.net v0.0.0-20200203144150-6677ee5c7211 h1:Qoe+9POtDT51UBQ8XEnS9QKeHDQzEl2QRh3eok9R4aw=
 go.starlark.net v0.0.0-20200203144150-6677ee5c7211/go.mod h1:nmDLcffg48OtT/PSW0Hg7FvpRQsQh5OSqIylirxKC7o=
 go.starlark.net v0.0.0-20210223155950-e043a3d3c984 h1:xwwDQW5We85NaTk2APgoN9202w/l0DVGp+GZMfsrh7s=


### PR DESCRIPTION
## Summary
- Parse `.buildifier.json` as JWCC/JSONC using [`github.com/tailscale/hujson`](https://github.com/tailscale/hujson), so configs can include `//` and `/* */` comments and trailing commas.
- Add unit tests covering comment stripping edge cases and end-to-end config loading.

## Justification
Editors and many tooling ecosystems treat `.json` config files as JSONC (VS Code, Cursor, etc.), but buildifier previously used `encoding/json` directly and rejected any comments. That mismatch forces users to choose between documented/annotated configs and a config that buildifier will actually load.

Using hujson gives spec-compliant JWCC parsing (RFC 8259 JSON plus comments and trailing commas) instead of a hand-rolled comment stripper, which is safer around strings containing `//` or `/*`.

## Implications

We might not be the only parser of this file. For example buildifier plugin for an IDE might have been written with a separate parser. I don't think we need to allow the file format to be a public API however.

## Test plan
- [x] `bazel test //buildifier/config:config_test`
- [ ] Verify a `.buildifier.json` with inline comments loads via `--config`