### PR TITLE
Add basic support for REPO.bazel and VENDOR.bazel files

### DIFF
--- a/build/lex.go
+++ b/build/lex.go
@@ -44,6 +44,10 @@ const (
 	TypeBzl
 	// TypeModule represents MODULE.bazel and *.MODULE.bazel files
 	TypeModule
+	// TypeRepo represents REPO.bazel files
+	TypeRepo
+	// TypeVendor represents VENDOR.bazel files
+	TypeVendor
 )
 
 func (t FileType) String() string {
@@ -58,6 +62,10 @@ func (t FileType) String() string {
 		return ".bzl"
 	case TypeModule:
 		return "MODULE.bazel"
+	case TypeRepo:
+		return "REPO.bazel"
+	case TypeVendor:
+		return "VENDOR.bazel"
 	}
 	return "unknown"
 }
@@ -98,6 +106,30 @@ func ParseModule(filename string, data []byte) (*File, error) {
 	return f, err
 }
 
+// ParseRepo parses a file, marks it as a REPO.bazel file and returns the corresponding parse tree.
+//
+// The filename is used only for generating error messages.
+func ParseRepo(filename string, data []byte) (*File, error) {
+	in := newInput(filename, data)
+	f, err := in.parse()
+	if f != nil {
+		f.Type = TypeRepo
+	}
+	return f, err
+}
+
+// ParseVendor parses a file, marks it as a VENDOR.bazel file and returns the corresponding parse tree.
+//
+// The filename is used only for generating error messages.
+func ParseVendor(filename string, data []byte) (*File, error) {
+	in := newInput(filename, data)
+	f, err := in.parse()
+	if f != nil {
+		f.Type = TypeVendor
+	}
+	return f, err
+}
+
 // ParseBzl parses a file, marks it as a .bzl file and returns the corresponding parse tree.
 //
 // The filename is used only for generating error messages.
@@ -133,6 +165,12 @@ func getFileType(filename string) FileType {
 	if basename == "module.bazel" || strings.HasSuffix(basename, ".module.bazel") {
 		return TypeModule
 	}
+	if basename == "repo.bazel" {
+		return TypeRepo
+	}
+	if basename == "vendor.bazel" {
+		return TypeVendor
+	}
 	ext := filepath.Ext(basename)
 	switch ext {
 	case ".bzl":
@@ -162,6 +200,10 @@ func Parse(filename string, data []byte) (*File, error) {
 		return ParseWorkspace(filename, data)
 	case TypeModule:
 		return ParseModule(filename, data)
+	case TypeRepo:
+		return ParseRepo(filename, data)
+	case TypeVendor:
+		return ParseVendor(filename, data)
 	case TypeBzl:
 		return ParseBzl(filename, data)
 	}

--- a/build/lex_test.go
+++ b/build/lex_test.go
@@ -53,6 +53,8 @@ func TestIsBuildFilename(t *testing.T) {
 		"module.bazel":        TypeModule,
 		"module.bzl":          TypeBzl,
 		"MODULE":              TypeDefault,
+		"REPO.bazel":          TypeRepo,
+		"VENDOR.bazel":        TypeVendor,
 	}
 	for name, fileType := range cases {
 		res := getFileType(name)

--- a/build/print.go
+++ b/build/print.go
@@ -89,7 +89,7 @@ type printer struct {
 // Can be only TypeBuild or TypeDefault.
 func (p *printer) formattingMode() FileType {
 	switch p.fileType {
-	case TypeBuild, TypeWorkspace, TypeModule:
+	case TypeBuild, TypeWorkspace, TypeModule, TypeRepo, TypeVendor:
 		return TypeBuild
 	default: // TypeDefault, TypeBzl
 		return TypeDefault

--- a/build/rewrite.go
+++ b/build/rewrite.go
@@ -111,8 +111,8 @@ func rewriteSetContains(w *Rewriter, name string) bool {
 // Each rewrite function can be either applied for BUILD files, other files (such as .bzl),
 // or all files.
 const (
-	scopeDefault = TypeDefault | TypeBzl                  // .bzl and generic Starlark files
-	scopeBuild   = TypeBuild | TypeWorkspace | TypeModule // BUILD, WORKSPACE, and MODULE files
+	scopeDefault = TypeDefault | TypeBzl                                          // .bzl and generic Starlark files
+	scopeBuild   = TypeBuild | TypeWorkspace | TypeModule | TypeRepo | TypeVendor // BUILD, WORKSPACE, MODULE, REPO, and VENDOR files
 	scopeBoth    = scopeDefault | scopeBuild
 )
 

--- a/buildifier/config/config.go
+++ b/buildifier/config/config.go
@@ -93,7 +93,8 @@ func findTablesPath(file string) (string, error) {
 type Config struct {
 	// InputType determines the input file type: build (for BUILD files), bzl
 	// (for .bzl files), workspace (for WORKSPACE files), default (for generic
-	// Starlark files), module (for MODULE.bazel files)
+	// Starlark files), module (for MODULE.bazel files),
+	// repo (for REPO.bazel files), vendor (for VENDOR.bazel files),
 	// or auto (default, based on the filename)
 	InputType string `json:"type,omitempty"`
 	// Format sets the diagnostics format: text or json (default text)
@@ -181,7 +182,7 @@ func (c *Config) FlagSet(name string, errorHandling flag.ErrorHandling) *flag.Fl
 	flags.StringVar(&c.WorkspaceRelativePath, "path", c.WorkspaceRelativePath, "assume BUILD file has this path relative to the workspace directory")
 	flags.StringVar(&c.TablesPath, "tables", c.TablesPath, "path to JSON file with custom table definitions which will replace the built-in tables")
 	flags.StringVar(&c.AddTablesPath, "add_tables", c.AddTablesPath, "path to JSON file with custom table definitions which will be merged with the built-in tables")
-	flags.StringVar(&c.InputType, "type", c.InputType, "Input file type: build (for BUILD files), bzl (for .bzl files), workspace (for WORKSPACE files), module (for MODULE.bazel files), default (for generic Starlark files) or auto (default, based on the filename)")
+	flags.StringVar(&c.InputType, "type", c.InputType, "Input file type: build (for BUILD files), bzl (for .bzl files), workspace (for WORKSPACE files), module (for MODULE.bazel files), repo (for REPO.bazel files), vendor (for VENDOR.bazel files), default (for generic Starlark files) or auto (default, based on the filename)")
 	flags.StringVar(&c.ConfigPath, "config", "", "path to .buildifier.json config file")
 	flags.Var(&c.AllowSort, "allowsort", "additional sort contexts to treat as safe")
 	flags.Var(&c.DisableRewrites, "buildifier_disable", "list of buildifier rewrites to disable")

--- a/buildifier/config/config_test.go
+++ b/buildifier/config/config_test.go
@@ -168,7 +168,7 @@ func ExampleFlagSet() {
 	// path: assume BUILD file has this path relative to the workspace directory ("")
 	// r: find starlark files recursively ("false")
 	// tables: path to JSON file with custom table definitions which will replace the built-in tables ("")
-	// type: Input file type: build (for BUILD files), bzl (for .bzl files), workspace (for WORKSPACE files), module (for MODULE.bazel files), default (for generic Starlark files) or auto (default, based on the filename) ("auto")
+	// type: Input file type: build (for BUILD files), bzl (for .bzl files), workspace (for WORKSPACE files), module (for MODULE.bazel files), repo (for REPO.bazel files), vendor (for VENDOR.bazel files), default (for generic Starlark files) or auto (default, based on the filename) ("auto")
 	// v: print verbose information to standard error ("false")
 	// version: print the version of buildifier ("false")
 	// warnings: comma-separated warnings used in the lint mode or "all" ("")
@@ -262,7 +262,7 @@ func TestValidate(t *testing.T) {
 		"type default":          {options: "--type=default"},
 		"type module":           {options: "--type=module"},
 		"type auto":             {options: "--type=auto"},
-		"type error":            {options: "--type=foo", wantErr: fmt.Errorf("unrecognized input type foo; valid types are build, bzl, workspace, default, module, auto")},
+		"type error":            {options: "--type=foo", wantErr: fmt.Errorf("unrecognized input type foo; valid types are build, bzl, workspace, default, module, repo, vendor, auto")},
 		"warnings all": {options: "--warnings=all", wantWarnings: []string{
 			"allowed-symbol-load-locations",
 			"attr-applicable_licenses",

--- a/buildifier/config/validation.go
+++ b/buildifier/config/validation.go
@@ -26,11 +26,11 @@ import (
 // ValidateInputType validates the value of --type
 func ValidateInputType(inputType *string) error {
 	switch *inputType {
-	case "build", "bzl", "workspace", "default", "module", "auto":
+	case "build", "bzl", "workspace", "default", "module", "repo", "vendor", "auto":
 		return nil
 
 	default:
-		return fmt.Errorf("unrecognized input type %s; valid types are build, bzl, workspace, default, module, auto", *inputType)
+		return fmt.Errorf("unrecognized input type %s; valid types are build, bzl, workspace, default, module, repo, vendor, auto", *inputType)
 	}
 }
 

--- a/buildifier/integration_test.sh
+++ b/buildifier/integration_test.sh
@@ -123,6 +123,14 @@ bazel_dep(name = "weird_dep", version = "3.19.0", dev_dependency = "True" == "Tr
 bazel_dep(name='yet_another_prod_dep',version='3.19.0')
 EOF
 
+cat > test_dir/REPO.bazel <<'EOF'
+repo(default_visibility='//visibility:private',default_testonly=False)
+EOF
+
+cat > test_dir/VENDOR.bazel << 'EOF'
+ignore ('foo')
+EOF
+
 cp test_dir/foo.bar golden/foo.bar
 cp test_dir/subdir/build golden/build
 cp test_dir/.git/git.bzl golden/git.bzl
@@ -252,6 +260,17 @@ bazel_dep(name = "weird_dep", version = "3.19.0", dev_dependency = "True" == "Tr
 bazel_dep(name = "yet_another_prod_dep", version = "3.19.0")
 EOF
 
+cat > golden/REPO.bazel.golden <<'EOF'
+repo(
+    default_testonly = False,
+    default_visibility = "//visibility:private",
+)
+EOF
+
+cat > golden/VENDOR.bazel.golden <<'EOF'
+ignore("foo")
+EOF
+
 cat > golden/.buildifier.example.json <<EOF
 {
   "type": "auto",
@@ -373,6 +392,8 @@ diff -u test2.bzl golden/test.bzl.golden
 diff -u stdout golden/test.bzl.golden
 diff -u test_dir/.git/git.bzl golden/git.bzl
 diff -u test_dir/MODULE.bazel golden/MODULE.bazel.golden
+diff -u test_dir/REPO.bazel golden/REPO.bazel.golden
+diff -u test_dir/VENDOR.bazel golden/VENDOR.bazel.golden
 diff -u test_dir/.buildifier.example.json golden/.buildifier.example.json
 
 # Test run on a directory without -r

--- a/buildifier/utils/utils.go
+++ b/buildifier/utils/utils.go
@@ -99,6 +99,10 @@ func GetParser(inputType string) func(filename string, data []byte) (*build.File
 		return build.ParseWorkspace
 	case "module":
 		return build.ParseModule
+	case "repo":
+		return build.ParseRepo
+	case "vendor":
+		return build.ParseVendor
 	default:
 		return build.ParseDefault
 	}

--- a/warn/warn_test.go
+++ b/warn/warn_test.go
@@ -32,9 +32,11 @@ const (
 	scopeWorkspace   = build.TypeWorkspace
 	scopeDefault     = build.TypeDefault
 	scopeModule      = build.TypeModule
-	scopeEverywhere  = scopeBuild | scopeBzl | scopeWorkspace | scopeDefault | scopeModule
-	scopeBazel       = scopeBuild | scopeBzl | scopeWorkspace | scopeModule
-	scopeDeclarative = scopeBuild | scopeWorkspace | scopeModule
+	scopeRepo        = build.TypeRepo
+	scopeVendor      = build.TypeVendor
+	scopeEverywhere  = scopeBuild | scopeBzl | scopeWorkspace | scopeDefault | scopeModule | scopeRepo | scopeVendor
+	scopeBazel       = scopeBuild | scopeBzl | scopeWorkspace | scopeModule | scopeRepo | scopeVendor
+	scopeDeclarative = scopeBuild | scopeWorkspace | scopeModule | scopeRepo | scopeVendor
 )
 
 // A global FileReader object that can be used by tests. If a test redefines it it must
@@ -88,6 +90,10 @@ func getFilename(fileType build.FileType) string {
 		return "test_file.bzl"
 	case build.TypeModule:
 		return "MODULE.bazel"
+	case build.TypeRepo:
+		return "REPO.bazel"
+	case build.TypeVendor:
+		return "VENDOR.bazel"
 	default:
 		return "test_file.strlrk"
 	}


### PR DESCRIPTION
## Buildtools PR checklist

- [x] The code in this PR is covered by unit/integration tests.
- [x] I have tested these changes and provide testing instructions below.
- [x] I have either responded to, or resolved all Gemini comments on the PR.
- [x] I have read Google Eng Practices on [Small Changes](https://google.github.io/eng-practices/review/developer/small-cls.html), this PR either follows these guidelines or the description provides reasoning for why they can not be followed.

## Description

Add basic support for REPO.bazel and VENDOR.bazel files

As these files are pretty trivial, we mostly treat them as generic BUILD-like files and only wire up type detection and the Buildifier --type flag.

### (optional) These changes were tested using the following steps
