### PR TITLE
Fix buildozer :expr changing E to e

### DIFF
--- a/buildozer/buildozer_test.sh
+++ b/buildozer/buildozer_test.sh
@@ -239,6 +239,21 @@ function test_add_override_expr() {
 )'
 }
 
+function test_add_override_expr_with_dot_and_capital_e() {
+  in='go_library(
+    name = "edit",
+    deps = ["build"],
+)'
+  run "$in" 'add deps:expr SYSTEMS.SYS1' '//pkg:edit'
+  assert_equals 'go_library(
+    name = "edit",
+    deps = [
+        SYSTEMS.SYS1,
+        "build",
+    ],
+)'
+}
+
 function test_add_override_unknown_type() {
   in='go_library(
     name = "edit",

--- a/edit/buildozer.go
+++ b/edit/buildozer.go
@@ -121,13 +121,13 @@ func cmdAdd(opts *Options, env CmdEnvironment) (*build.File, error) {
 	}
 	for _, val := range env.Args[1:] {
 		if attrType == rawAttr {
-    	AddValueToListAttribute(env.Rule, attr, env.Pkg, &build.Ident{Name: val}, &env.Vars)
-    	continue
-    }
-    if attrType == notProvidedTypeAttr && IsIntList(attr) {
-    	 AddValueToListAttribute(env.Rule, attr, env.Pkg, &build.LiteralExpr{Token: val}, &env.Vars)
-    	continue
-    }
+	    	AddValueToListAttribute(env.Rule, attr, env.Pkg, &build.Ident{Name: val}, &env.Vars)
+	    	continue
+    	}
+	    if attrType == notProvidedTypeAttr && IsIntList(attr) {
+	    	AddValueToListAttribute(env.Rule, attr, env.Pkg, &build.LiteralExpr{Token: val}, &env.Vars)
+	    	continue
+	    }
 		var strVal build.Expr
 		strVal = getLabelStringExpr(val, env.Pkg)
 		AddValueToListAttribute(env.Rule, attr, env.Pkg, strVal, &env.Vars)

--- a/edit/buildozer.go
+++ b/edit/buildozer.go
@@ -120,10 +120,14 @@ func cmdAdd(opts *Options, env CmdEnvironment) (*build.File, error) {
 		return nil, err
 	}
 	for _, val := range env.Args[1:] {
-		if attrType == rawAttr || (attrType == notProvidedTypeAttr && IsIntList(attr)) {
-			AddValueToListAttribute(env.Rule, attr, env.Pkg, &build.LiteralExpr{Token: val}, &env.Vars)
-			continue
-		}
+		if attrType == rawAttr {
+    	AddValueToListAttribute(env.Rule, attr, env.Pkg, &build.Ident{Name: val}, &env.Vars)
+    	continue
+    }
+    if attrType == notProvidedTypeAttr && IsIntList(attr) {
+    	 AddValueToListAttribute(env.Rule, attr, env.Pkg, &build.LiteralExpr{Token: val}, &env.Vars)
+    	continue
+    }
 		var strVal build.Expr
 		strVal = getLabelStringExpr(val, env.Pkg)
 		AddValueToListAttribute(env.Rule, attr, env.Pkg, strVal, &env.Vars)


### PR DESCRIPTION
## Buildtools PR checklist

- [x] The code in this PR is covered by unit/integration tests.
- [x] I have tested these changes and provide testing instructions below.
- [x] I have either responded to, or resolved all Gemini comments on the PR.
- [x] I have read Google Eng Practices on [Small Changes](https://google.github.io/eng-practices/review/developer/small-cls.html), this PR either follows these guidelines or the description provides reasoning for why they can not be followed.

## Description
Fix buildozer :expr changing E to e.

When an :expr is added with a dot and an uppercase E (like SYSTEMS.SYS1), it is mistakenly treated as a float in scientific notation. Because it was being saved by cmdAdd as a LiteralExpr node (which is strictly meant for numbers), the float formatter is triggered and the E is incorrectly changed to a lowercase e (SYSTeMS.SYS1). Changing cmdAdd to use an Ident node instead fixes this, because the float formatter is skipped entirely. This matches how cmdSet already handles it.